### PR TITLE
use ipstack with api key and legacy format

### DIFF
--- a/lib/geoip/config.ex
+++ b/lib/geoip/config.ex
@@ -2,6 +2,7 @@ defmodule GeoIP.Config do
   def base_url, do: get(:url)
   def cache_enabled?, do: get(:cache)
   def cache_ttl_secs, do: get(:cache_ttl_secs)
+  def api_access_key, do: get(:api_access_key)
 
   defp get(key), do: Application.get_env(:geoip, key)
 end

--- a/lib/geoip/lookup.ex
+++ b/lib/geoip/lookup.ex
@@ -29,7 +29,13 @@ defmodule GeoIP.Lookup do
   defp put_in_cache(result, _), do: result
 
   defp parse_response({:ok, %HTTPoison.Response{status_code: 200, body: body}}) do
-    {:ok, Poison.decode!(body, as: %Location{})}
+    json_result = Poison.decode!(body)
+
+    if !Map.get(json_result, "success") == false do
+      {:error, %Error{reason: body}}
+    else
+      {:ok, Poison.decode!(body, as: %Location{})}
+    end
   end
 
   defp parse_response({:ok, %HTTPoison.Response{status_code: _, body: body}}) do
@@ -44,5 +50,5 @@ defmodule GeoIP.Lookup do
     {:error, %Error{reason: "Error looking up host: #{inspect(result)}"}}
   end
 
-  defp lookup_url(host), do: "#{Config.base_url}/json/#{host}"
+  defp lookup_url(host), do: "#{Config.base_url}/#{host}?access_key=#{Config.api_access_key}&legacy=1"
 end


### PR DESCRIPTION
- add: handle `api_access_key` environment variable
- update: base url with legacy using api access key
- fix: `parse_response` returns an error, when body has the attribute `success: false`